### PR TITLE
Fix test timeout issue with non-interactive reporters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,4 @@
 - Do things the right way. If that isn't working, it can be better to kick it back to me and we can discuss. Sometimes you tend to thrash and create horrible workarounds. This doesn't help. Don't do it.
 - Every page should look great on desktop and mobile
 - The notes in our app DO NOT have previews or titles. Don't add these fields.
+- When running tests, use `bun test:ci` or `npm run test:ci` instead of `bun test` to avoid timeouts. The regular test command starts an HTML report server that doesn't exit automatically.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "typecheck": "tsc --noEmit && tsc -p tsconfig.static.json --noEmit",
     "clean": "rimraf dist",
     "test": "playwright test",
-    "test:ui": "playwright test --ui"
+    "test:ui": "playwright test --ui",
+    "test:ci": "playwright test --reporter=list"
   },
   "keywords": [],
   "author": "",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: 'html',
+  reporter: process.env.CI ? 'list' : [['html', { open: 'never' }]],
   use: {
     baseURL: `http://localhost:${port}`,
     trace: 'on-first-retry',


### PR DESCRIPTION
## Summary
- Configured Playwright to use non-interactive reporters to prevent timeout issues
- Added dedicated test:ci script for automated test runs
- Updated CLAUDE.md with testing instructions

## Test plan
- [ ] Run `npm run test:ci` and verify tests complete without hanging
- [ ] Run `npm run test` and verify HTML report doesn't auto-open but tests still run
- [ ] Verify CI builds pass with the new reporter configuration

🤖 Generated with [Claude Code](https://claude.ai/code)