### PR TITLE
Fix hot-reload SSE endpoint authentication issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,8 @@ function needsAuth(path: string): boolean {
   if (path === '/login') return false;
   // Static files don't need auth
   if (path.startsWith('/static/')) return false;
+  // Hot-reload SSE doesn't need auth (development only)
+  if (path === '/hot-reload-sse') return false;
   return true;
 }
 


### PR DESCRIPTION
## Summary
- Fixed EventSource connection errors that were making the app unusable in development mode
- The /hot-reload-sse endpoint was being caught by authentication middleware, causing redirects to login page
- This resulted in "text/html" MIME type errors instead of the expected "text/event-stream"

## Changes
- Excluded `/hot-reload-sse` endpoint from authentication requirements in `needsAuth()` function
- This allows the SSE connection to work properly in development mode

## Test plan
- [x] Start development server with `npm run dev`
- [x] Verify no EventSource errors in browser console
- [x] Confirm SSE endpoint returns correct `Content-Type: text/event-stream` header
- [x] App remains usable without constant reloading

🤖 Generated with [Claude Code](https://claude.ai/code)