### PR TITLE
Add epub reading position persistence

### DIFF
--- a/src/db/embedded-migrations.ts
+++ b/src/db/embedded-migrations.ts
@@ -7,6 +7,8 @@ export const EMBEDDED_MIGRATIONS: Record<string, string> = {
   '0000_marvelous_elektra.sql': readFileSync('./src/db/migrations/0000_marvelous_elektra.sql', 'utf-8'),
   '0001_nice_young_avengers.sql': readFileSync('./src/db/migrations/0001_nice_young_avengers.sql', 'utf-8'),
   '0002_remove_tigris.sql': readFileSync('./src/db/migrations/0002_remove_tigris.sql', 'utf-8'),
+  '0003_add_epub_reading_positions.sql': readFileSync('./src/db/migrations/0003_add_epub_reading_positions.sql', 'utf-8'),
+  '0004_add_font_size_to_epub_positions.sql': readFileSync('./src/db/migrations/0004_add_font_size_to_epub_positions.sql', 'utf-8'),
   
   // Meta files
   'meta/_journal.json': readFileSync('./src/db/migrations/meta/_journal.json', 'utf-8'),

--- a/src/db/migrations/0003_add_epub_reading_positions.sql
+++ b/src/db/migrations/0003_add_epub_reading_positions.sql
@@ -1,0 +1,12 @@
+-- Create epub_reading_positions table
+CREATE TABLE epub_reading_positions (
+  id TEXT PRIMARY KEY,
+  file_id TEXT NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+  cfi TEXT NOT NULL,
+  percentage INTEGER NOT NULL DEFAULT 0,
+  updated_at INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create indexes for epub_reading_positions
+CREATE INDEX epub_reading_positions_file_id_idx ON epub_reading_positions(file_id);
+CREATE INDEX epub_reading_positions_updated_at_idx ON epub_reading_positions(updated_at);

--- a/src/db/migrations/0004_add_font_size_to_epub_positions.sql
+++ b/src/db/migrations/0004_add_font_size_to_epub_positions.sql
@@ -1,0 +1,2 @@
+-- Add font_size column to epub_reading_positions table
+ALTER TABLE epub_reading_positions ADD COLUMN font_size INTEGER NOT NULL DEFAULT 100;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -31,7 +31,21 @@ export const files = sqliteTable('files', {
   uploadedAtIdx: index('files_uploaded_at_idx').on(table.uploadedAt),
 }));
 
+export const epubReadingPositions = sqliteTable('epub_reading_positions', {
+  id: text('id').primaryKey(),
+  fileId: text('file_id').notNull().references(() => files.id, { onDelete: 'cascade' }),
+  cfi: text('cfi').notNull(), // EPUB CFI (Canonical Fragment Identifier) for precise position
+  percentage: integer('percentage').notNull().default(0), // Reading percentage (0-100)
+  fontSize: integer('font_size').notNull().default(100), // Font size percentage (50-200)
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().default(sql`CURRENT_TIMESTAMP`),
+}, (table) => ({
+  fileIdIdx: index('epub_reading_positions_file_id_idx').on(table.fileId),
+  updatedAtIdx: index('epub_reading_positions_updated_at_idx').on(table.updatedAt),
+}));
+
 export type Note = typeof notes.$inferSelect;
 export type NewNote = typeof notes.$inferInsert;
 export type File = typeof files.$inferSelect;
 export type NewFile = typeof files.$inferInsert;
+export type EpubReadingPosition = typeof epubReadingPositions.$inferSelect;
+export type NewEpubReadingPosition = typeof epubReadingPositions.$inferInsert;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,9 @@ import { config } from './config';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { fileStorage } from './services/file-storage';
+import { db } from './db/index';
+import { epubReadingPositions } from './db/schema';
+import { eq } from 'drizzle-orm';
 
 // Templates
 import { HomePage } from './templates/HomePage';
@@ -225,6 +228,16 @@ Bun.serve({
       return handleGetFileUrl(fileUrlMatch[1]);
     }
 
+    // Reading position API endpoints
+    if (path === '/api/reading-position' && req.method === 'POST') {
+      return handleSaveReadingPosition(req);
+    }
+    
+    const positionMatch = path.match(/^\/api\/reading-position\/([a-f0-9-]+)$/);
+    if (positionMatch && req.method === 'GET') {
+      return handleGetReadingPosition(positionMatch[1]);
+    }
+
     return notFound();
   }
 });
@@ -429,7 +442,7 @@ async function handleEpubViewer(fileId: string): Promise<Response> {
     const bookName = fileInfo.originalName.replace(/\.epub$/i, '');
     const bookUrl = `/epub-file/${encodeURIComponent(fileId)}`;
     
-    return htmlResponse(EpubReaderPage({ bookName, bookUrl }) as string);
+    return htmlResponse(EpubReaderPage({ bookName, bookUrl, fileId }) as string);
   } catch (error) {
     console.error('Error fetching book:', error);
     return notFound();
@@ -581,6 +594,79 @@ async function handleGetFileUrl(fileId: string): Promise<Response> {
   } catch (error) {
     console.error('Get file URL error:', error);
     return new Response('Failed to get URL', { status: 500 });
+  }
+}
+
+// Reading position handlers
+async function handleSaveReadingPosition(req: Request): Promise<Response> {
+  try {
+    const data = await req.json() as { fileId: string; cfi: string; percentage: number; fontSize?: number };
+    
+    if (!data.fileId || !data.cfi) {
+      return new Response('Missing required fields', { status: 400 });
+    }
+    
+    // Check if position exists for this file
+    const existing = await db.select()
+      .from(epubReadingPositions)
+      .where(eq(epubReadingPositions.fileId, data.fileId))
+      .limit(1);
+    
+    if (existing.length > 0) {
+      // Update existing position
+      await db.update(epubReadingPositions)
+        .set({
+          cfi: data.cfi,
+          percentage: data.percentage || 0,
+          fontSize: data.fontSize || 100,
+          updatedAt: new Date()
+        })
+        .where(eq(epubReadingPositions.id, existing[0].id));
+    } else {
+      // Create new position
+      await db.insert(epubReadingPositions)
+        .values({
+          id: crypto.randomUUID(),
+          fileId: data.fileId,
+          cfi: data.cfi,
+          percentage: data.percentage || 0,
+          fontSize: data.fontSize || 100,
+          updatedAt: new Date()
+        });
+    }
+    
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { 'Content-Type': 'application/json' }
+    });
+  } catch (error) {
+    console.error('Save reading position error:', error);
+    return new Response('Failed to save position', { status: 500 });
+  }
+}
+
+async function handleGetReadingPosition(fileId: string): Promise<Response> {
+  try {
+    const position = await db.select()
+      .from(epubReadingPositions)
+      .where(eq(epubReadingPositions.fileId, fileId))
+      .limit(1);
+    
+    if (position.length === 0) {
+      return new Response(JSON.stringify({ cfi: null, percentage: 0, fontSize: 100 }), {
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+    
+    return new Response(JSON.stringify({
+      cfi: position[0].cfi,
+      percentage: position[0].percentage,
+      fontSize: position[0].fontSize || 100
+    }), {
+      headers: { 'Content-Type': 'application/json' }
+    });
+  } catch (error) {
+    console.error('Get reading position error:', error);
+    return new Response('Failed to get position', { status: 500 });
   }
 }
 

--- a/src/input.css
+++ b/src/input.css
@@ -80,11 +80,15 @@
   }
 
   .reader-controls {
-    @apply flex gap-2;
+    @apply flex gap-2 items-center;
   }
 
   .reader-content {
     @apply border-2 border-dark p-4 bg-white;
+  }
+  
+  .font-size-display {
+    @apply px-2 text-sm font-mono;
   }
 }
 

--- a/src/templates/EpubReaderPage.tsx
+++ b/src/templates/EpubReaderPage.tsx
@@ -5,9 +5,10 @@ import { Nav, NavScript } from './Nav.js';
 interface EpubReaderPageProps {
   bookName: string;
   bookUrl: string;
+  fileId: string;
 }
 
-export const EpubReaderPage = ({ bookName, bookUrl }: EpubReaderPageProps) => (
+export const EpubReaderPage = ({ bookName, bookUrl, fileId }: EpubReaderPageProps) => (
   <Layout title={`Reading: ${bookName}`}>
     <div id="app">
       <Nav isHidden={true} />
@@ -21,6 +22,7 @@ export const EpubReaderPage = ({ bookName, bookUrl }: EpubReaderPageProps) => (
       window.addEventListener('DOMContentLoaded', () => {
         const container = document.getElementById('epub-reader-container');
         const reader = document.createElement('epub-reader');
+        reader.setAttribute('file-id', '${fileId}');
         container.appendChild(reader);
         reader.loadBook('${bookUrl}');
       });

--- a/src/templates/Nav.tsx
+++ b/src/templates/Nav.tsx
@@ -18,7 +18,7 @@ export const Nav = ({ currentPage, hideableClass = 'nav-hideable', isHidden = fa
   return (
     <header 
       class={`flex justify-between items-center mb-8 pb-4 border-b-4 border-double border-dark transition-transform duration-300 ${hideableClass} ${isHidden ? '-translate-y-full' : ''}`}
-      style={isHidden ? 'transform: translateY(-100%);' : ''}
+      style={isHidden ? 'display: none;' : ''}
     >
       <h1 class="text-4xl font-bold">
         <a href="/" class="no-underline hover:underline">Slipbox</a>

--- a/static/epub-reader.ts
+++ b/static/epub-reader.ts
@@ -20,40 +20,53 @@ interface Book {
 }
 
 interface Rendition {
-  display(): Promise<void>;
+  display(target?: string): Promise<void>;
   resize(): void;
   prev(): void;
   next(): void;
   destroy(): void;
-  on(event: string, handler: (event: TouchEvent) => void): void;
+  on(event: string, handler: (event: any) => void): void;
+  currentLocation(): any;
+  themes: {
+    fontSize(size: string): void;
+  };
 }
 
 class EpubReader extends HTMLElement {
   private book: Book | null = null;
   private rendition: Rendition | null = null;
+  private fileId: string | null = null;
+  private savePositionTimeout: NodeJS.Timeout | null = null;
+  private currentFontSize: number = 100;
 
   constructor() {
     super();
   }
 
   connectedCallback(): void {
+    this.fileId = this.getAttribute('file-id');
     this.innerHTML = `
       <div class="reader-header">
         <button class="reader-btn" id="back-btn">← Back to Library</button>
         <div class="reader-title">Loading...</div>
         <div class="reader-controls">
+          <button class="reader-btn" id="decrease-font-btn">A-</button>
+          <button class="reader-btn" id="increase-font-btn">A+</button>
+          <span class="font-size-display" id="font-size-display">100%</span>
           <button class="reader-btn" id="prev-btn">Previous</button>
           <button class="reader-btn" id="next-btn">Next</button>
         </div>
       </div>
-      <div class="reader-content">
-        <div id="epub-viewer"></div>
+      <div class="reader-content" style="border: none; padding: 0; margin: 0; background: white;">
+        <div id="epub-viewer" style="height: calc(100vh - 120px);"></div>
       </div>
     `;
     
     this.querySelector('#back-btn')!.addEventListener('click', () => this.goBack());
     this.querySelector('#prev-btn')!.addEventListener('click', () => this.prevPage());
     this.querySelector('#next-btn')!.addEventListener('click', () => this.nextPage());
+    this.querySelector('#decrease-font-btn')!.addEventListener('click', () => this.decreaseFontSize());
+    this.querySelector('#increase-font-btn')!.addEventListener('click', () => this.increaseFontSize());
   }
 
   async loadBook(url: string): Promise<void> {
@@ -84,7 +97,30 @@ class EpubReader extends HTMLElement {
         minSpreadWidth: 800
       });
       
-      await this.rendition.display();
+      // Load saved position and font size if exists
+      if (this.fileId) {
+        const position = await this.loadSavedPosition();
+        if (position) {
+          if (position.fontSize) {
+            this.currentFontSize = position.fontSize;
+            this.applyFontSize();
+          }
+          if (position.cfi) {
+            await this.rendition.display(position.cfi);
+          } else {
+            await this.rendition.display();
+          }
+        } else {
+          await this.rendition.display();
+        }
+      } else {
+        await this.rendition.display();
+      }
+      
+      // Set up position saving on location change
+      this.rendition.on('relocated', () => {
+        this.savePositionDebounced();
+      });
       
       document.addEventListener('keyup', this.handleKeyboard.bind(this));
       
@@ -134,16 +170,103 @@ class EpubReader extends HTMLElement {
   private prevPage(): void {
     if (this.rendition) {
       this.rendition.prev();
+      this.savePositionDebounced();
     }
   }
 
   private nextPage(): void {
     if (this.rendition) {
       this.rendition.next();
+      this.savePositionDebounced();
+    }
+  }
+  
+  private async loadSavedPosition(): Promise<{ cfi: string | null; percentage: number; fontSize: number } | null> {
+    if (!this.fileId) return null;
+    
+    try {
+      const response = await fetch(`/api/reading-position/${this.fileId}`);
+      if (response.ok) {
+        return await response.json();
+      }
+    } catch (error) {
+      console.error('Failed to load reading position:', error);
+    }
+    return null;
+  }
+  
+  private savePositionDebounced(): void {
+    if (!this.fileId || !this.rendition) return;
+    
+    // Clear existing timeout
+    if (this.savePositionTimeout) {
+      clearTimeout(this.savePositionTimeout);
+    }
+    
+    // Save position after 1 second of no activity
+    this.savePositionTimeout = setTimeout(() => {
+      this.savePosition();
+    }, 1000);
+  }
+  
+  private async savePosition(): Promise<void> {
+    if (!this.fileId || !this.rendition) return;
+    
+    try {
+      const location = this.rendition.currentLocation();
+      if (!location || !location.start) return;
+      
+      const cfi = location.start.cfi;
+      const percentage = location.start.percentage || 0;
+      
+      await fetch('/api/reading-position', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          fileId: this.fileId,
+          cfi: cfi,
+          percentage: Math.round(percentage * 100),
+          fontSize: this.currentFontSize
+        }),
+      });
+    } catch (error) {
+      console.error('Failed to save reading position:', error);
     }
   }
 
+  private increaseFontSize(): void {
+    if (this.currentFontSize < 200) {
+      this.currentFontSize += 10;
+      this.applyFontSize();
+      this.savePositionDebounced();
+    }
+  }
+  
+  private decreaseFontSize(): void {
+    if (this.currentFontSize > 50) {
+      this.currentFontSize -= 10;
+      this.applyFontSize();
+      this.savePositionDebounced();
+    }
+  }
+  
+  private applyFontSize(): void {
+    if (this.rendition) {
+      this.rendition.themes.fontSize(`${this.currentFontSize}%`);
+      const display = this.querySelector('#font-size-display') as HTMLElement;
+      if (display) {
+        display.textContent = `${this.currentFontSize}%`;
+      }
+    }
+  }
+  
+  
   private goBack(): void {
+    // Save position before leaving
+    this.savePosition();
+    
     if (this.rendition) {
       this.rendition.destroy();
     }


### PR DESCRIPTION
## Summary
- Adds persistent reading position tracking for epub files using CFI (Canonical Fragment Identifier)
- Implements font size controls with persistence (50%-200% range)
- Removes problematic 'H' hotkey that caused re-rendering issues

## Features
- Database schema for storing epub reading positions
- Automatic position saving when navigating pages
- Font size adjustment buttons (A-/A+) with persistence
- Restores last reading position and font size when reopening books

## Test plan
- [ ] Open an epub file and navigate to a specific page
- [ ] Adjust font size using A-/A+ buttons
- [ ] Navigate away and return to the epub - position and font size should be restored
- [ ] Test on multiple epub files to ensure positions are tracked separately
- [ ] Verify arrow keys still work for navigation
- [ ] Confirm 'H' hotkey no longer triggers

🤖 Generated with [Claude Code](https://claude.ai/code)