### PR TITLE
Remove navigation border lines

### DIFF
--- a/src/templates/Header.tsx
+++ b/src/templates/Header.tsx
@@ -5,7 +5,7 @@ interface HeaderProps {
 }
 
 export const Header = ({ children }: HeaderProps) => (
-  <header class="flex justify-between items-center mb-8 pb-4 border-b-4 border-double border-dark">
+  <header class="flex justify-between items-center mb-8">
     <h1 class="text-4xl font-bold">
       <a href="/" class="no-underline hover:underline">Slipbox</a>
     </h1>

--- a/src/templates/Nav.tsx
+++ b/src/templates/Nav.tsx
@@ -17,7 +17,7 @@ export const Nav = ({ currentPage, hideableClass = 'nav-hideable', isHidden = fa
 
   return (
     <header 
-      class={`flex justify-between items-center mb-8 pb-4 border-b-4 border-double border-dark transition-transform duration-300 ${hideableClass} ${isHidden ? '-translate-y-full' : ''}`}
+      class={`flex justify-between items-center mb-8 transition-transform duration-300 ${hideableClass} ${isHidden ? '-translate-y-full' : ''}`}
       style={isHidden ? 'display: none;' : ''}
     >
       <h1 class="text-4xl font-bold">


### PR DESCRIPTION
## Summary
- Removed the double border line under "Slipbox" title
- Removed the separator line between navigation and search field
- Cleaned up associated padding for cleaner UI

## Test plan
- [x] Verify navigation displays without border lines
- [x] Check layout spacing remains appropriate
- [x] Test on both desktop and mobile views

🤖 Generated with [Claude Code](https://claude.ai/code)