### PR TITLE
Redirect to home page after note deletion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -453,7 +453,7 @@ async function handleDeleteNote(id: string): Promise<Response> {
   }
 
   return ServerSentEventGenerator.stream((stream) => {
-    stream.patchElements(`<meta http-equiv="refresh" content="0; url=/">`);
+    stream.patchElements(`<script>window.location.href = '/';</script>`);
   });
 }
 


### PR DESCRIPTION
## Summary
- Replace meta refresh with JavaScript redirect for cleaner navigation after deleting a note

## Test plan
- [x] Delete a note and verify redirect to home page works
- [x] Ensure build passes

🤖 Generated with [Claude Code](https://claude.ai/code)