### PR TITLE
Fix post-PR cleanup to kill entire tmux window

### DIFF
--- a/scripts/post-pr-cleanup.sh
+++ b/scripts/post-pr-cleanup.sh
@@ -38,10 +38,10 @@ if [ "$IS_WORKTREE" = "true" ] && [ -n "$WORKTREE_PATH" ]; then
     git worktree remove "$WORKTREE_PATH" --force 2>/dev/null || echo "Worktree already removed"
 fi
 
-# Close tmux pane if we're in tmux
+# Close tmux window if we're in tmux
 if [ -n "$TMUX" ]; then
-    echo "Detected tmux session, closing pane..."
-    tmux kill-pane
+    echo "Detected tmux session, closing window..."
+    tmux kill-window
 fi
 
 echo "✨ Cleanup complete!"


### PR DESCRIPTION
## Summary
- Changed `tmux kill-pane` to `tmux kill-window` in the post-PR cleanup script
- This ensures all splits/panes associated with the PR/worktree are closed, not just the current pane

## Test plan
- [x] Script syntax validation passes
- [ ] Test with a tmux session containing multiple splits
- [ ] Verify window is killed after PR merge

🤖 Generated with [Claude Code](https://claude.ai/code)