### PR TITLE
Fix client asset paths to match embedded build structure

### DIFF
--- a/src/templates/EpubReaderPage.tsx
+++ b/src/templates/EpubReaderPage.tsx
@@ -16,7 +16,7 @@ export const EpubReaderPage = ({ bookName, bookUrl, fileId }: EpubReaderPageProp
     </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/epubjs@0.3/dist/epub.js"></script>
-    <script src="/client/epub-reader.js"></script>
+    <script src="/dist/client/epub-reader.js"></script>
     <script>{`
       // Initialize the reader when page loads
       window.addEventListener('DOMContentLoaded', () => {

--- a/src/templates/Layout.tsx
+++ b/src/templates/Layout.tsx
@@ -19,7 +19,7 @@ export const Layout = ({ title, children }: LayoutProps) => (
       ) : (
         <link rel="stylesheet" href={`/dist/style.css?v=${Date.now()}`} />
       )}
-      <script type="module" src="/client/datastar.js"></script>
+      <script type="module" src="/dist/client/datastar.js"></script>
       {isDev && (
         <script type="text/javascript">{`
           (function() {


### PR DESCRIPTION
## Summary
- Fixed HTML templates to reference client JavaScript files at `/dist/client/*.js` instead of `/client/*.js`
- This matches the paths used by embed-assets.ts and the build system
- Ensures the compiled binary correctly serves bundled JavaScript files

## Test plan
- [x] Build project with `bun run build`
- [x] Verify dist/client/ contains datastar.js and epub-reader.js
- [x] Build production binary with `NODE_ENV=production bun run build`
- [ ] Test that compiled binary serves assets correctly

🤖 Generated with [Claude Code](https://claude.ai/code)