### PR TITLE
Improve port visibility in dev mode

### DIFF
--- a/scripts/dev-with-tailwind.js
+++ b/scripts/dev-with-tailwind.js
@@ -43,11 +43,13 @@ async function main() {
     await new Promise(resolve => setTimeout(resolve, 2000));
 
     const port = await getAvailablePort();
-    console.log(`Starting server on port ${port}...`);
+    console.log(`\n${'='.repeat(50)}`);
+    console.log(`🚀 Starting Slipbox server on port ${port}`);
+    console.log(`${'='.repeat(50)}\n`);
     
     // Start the server with the found port
     const server = spawn('bun', ['--watch', 'src/index.ts'], {
-      env: { ...process.env, PORT: port.toString() },
+      env: { ...process.env, PORT: port.toString(), DEV_MODE: 'true' },
       stdio: 'inherit'
     });
 
@@ -56,15 +58,22 @@ async function main() {
     
     // Open browser
     const url = `http://localhost:${port}`;
-    console.log(`Opening ${url} in browser...`);
+    console.log(`\n📱 Browser opening: ${url}`);
+    console.log(`${'='.repeat(50)}\n`);
     
     const openCommand = process.platform === 'darwin' ? 'open' :
                        process.platform === 'win32' ? 'start' : 'xdg-open';
     
     spawn(openCommand, [url], { detached: true });
 
+    // Show port periodically in dev mode
+    const portReminder = setInterval(() => {
+      console.log(`\n[Slipbox] Server running on http://localhost:${port}`);
+    }, 30000); // Every 30 seconds
+
     // Handle exit
     process.on('SIGINT', () => {
+      clearInterval(portReminder);
       tailwind.kill();
       server.kill();
       process.exit();

--- a/src/index.ts
+++ b/src/index.ts
@@ -899,4 +899,11 @@ async function handleGetReadingPosition(fileId: string): Promise<Response> {
   }
 }
 
-console.log(`Slipbox server running at http://localhost:${config.port}`);
+// Make port visible on every restart
+const separator = '='.repeat(50);
+console.log(`\n${separator}`);
+console.log(`🚀 Slipbox server running at http://localhost:${config.port}`);
+if (process.env.DEV_MODE === 'true') {
+  console.log(`📝 Watching for file changes...`);
+}
+console.log(`${separator}\n`);


### PR DESCRIPTION
- Add prominent banners showing port on server start
- Display port reminder every 30 seconds in dev mode
- Show clear port message on every server restart
- Add visual separators to make port info stand out

This ensures the port number is always visible and doesn't get lost
in console output during development.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
