### PR TITLE
Remove special naming for master branch in init.sh

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -13,26 +13,14 @@ WORKTREE_DIR=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || "unknown")
 
 # Create a unique tmp directory for this worktree
-# Special handling for master branch vs worktrees
-if [ "$CURRENT_BRANCH" = "master" ]; then
-    # Use master-specific directory with tmux pane ID if available
-    if [ -n "$TMUX_PANE" ]; then
-        PANE_ID=$(echo "$TMUX_PANE" | sed 's/[^0-9]//g')
-        TMP_SUFFIX="master-pane-${PANE_ID}"
-    else
-        TMP_SUFFIX="master-$$"
-    fi
+if [ -n "$TMUX_PANE" ]; then
+    # Extract pane ID (e.g., %0, %1, etc.)
+    PANE_ID=$(echo "$TMUX_PANE" | sed 's/[^0-9]//g')
+    TMP_SUFFIX="pane-${PANE_ID}"
 else
-    # For worktrees, use existing logic
-    if [ -n "$TMUX_PANE" ]; then
-        # Extract pane ID (e.g., %0, %1, etc.)
-        PANE_ID=$(echo "$TMUX_PANE" | sed 's/[^0-9]//g')
-        TMP_SUFFIX="pane-${PANE_ID}"
-    else
-        # Use worktree name + PID as fallback
-        WORKTREE_NAME=$(basename "$WORKTREE_DIR")
-        TMP_SUFFIX="${WORKTREE_NAME}-$$"
-    fi
+    # Use worktree name + PID as fallback
+    WORKTREE_NAME=$(basename "$WORKTREE_DIR")
+    TMP_SUFFIX="${WORKTREE_NAME}-$$"
 fi
 
 # Create isolated data directory in /tmp
@@ -191,11 +179,6 @@ else
 fi
 
 echo ""
-if [ "$CURRENT_BRANCH" = "master" ]; then
-    echo "✅ Master branch initialization complete!"
-    echo "   Each terminal session will use: $SLIPBOX_DATA_DIR"
-else
-    echo "✅ Worktree initialization complete!"
-    echo "   Each terminal in this worktree will use: $SLIPBOX_DATA_DIR"
-fi
+echo "✅ Initialization complete!"
+echo "   Data directory: $SLIPBOX_DATA_DIR"
 echo "   Run 'npm run dev' to start the development server."


### PR DESCRIPTION
The init.sh script no longer uses special directory naming for the master branch.
All branches now use the same naming convention (e.g., /tmp/slipbox-data-pane-59
instead of /tmp/slipbox-data-master-pane-59).

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
