### PR TITLE
Add auto-login for development mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Zettelkasten-style note-taking app built with Datastar framework",
   "main": "dist/index.js",
   "scripts": {
-    "dev": "bun scripts/dev-with-tailwind.js",
+    "dev": "bun scripts/dev.js",
     "init": "./scripts/init.sh",
     "reset-datadir": "./scripts/reset-datadir.sh",
     "build:client": "bun scripts/build.js",

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -28,6 +28,12 @@ async function getAvailablePort(startPort = 3000) {
 // Main
 async function main() {
   try {
+    // Assert we're in development mode
+    if (process.env.NODE_ENV === 'production') {
+      console.error('❌ This is a development script and should not be run in production!');
+      process.exit(1);
+    }
+    
     // Ensure dist directory exists
     if (!existsSync('dist')) {
       mkdirSync('dist');
@@ -56,8 +62,8 @@ async function main() {
     // Wait a moment for server to start
     await new Promise(resolve => setTimeout(resolve, 1000));
     
-    // Open browser
-    const url = `http://localhost:${port}`;
+    // This is a dev script - always go to auto-login
+    const url = `http://localhost:${port}/auto-login`;
     console.log(`\n📱 Browser opening: ${url}`);
     console.log(`${'='.repeat(50)}\n`);
     

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,6 +203,8 @@ function needsAuth(path: string): boolean {
   if (process.env.NODE_ENV === 'test') return false;
   // Login page doesn't need auth
   if (path === '/login') return false;
+  // Auto-login route doesn't need auth (development only)
+  if (path === '/auto-login' && process.env.NODE_ENV !== 'production') return false;
   // Static files don't need auth
   if (path.startsWith('/static/') || path.startsWith('/client/') || path.startsWith('/dist/')) return false;
   // Hot-reload SSE doesn't need auth (development only)
@@ -281,6 +283,13 @@ Bun.serve({
         
       case '/logout':
         return handleLogout(req);
+        
+      case '/auto-login':
+        // Development-only auto-login route
+        if (process.env.NODE_ENV !== 'production') {
+          return handleAutoLogin();
+        }
+        break;
         
       case '/':
         return handleHome(url);
@@ -434,6 +443,35 @@ function handleLogout(req: Request): Response {
     headers: {
       'Location': '/login',
       'Set-Cookie': 'session=; Path=/; HttpOnly; SameSite=Strict; Max-Age=0'
+    }
+  });
+}
+
+function handleAutoLogin(): Response {
+  // Create session automatically for development
+  const token = generateSessionToken();
+  sessions.set(token, { expires: Date.now() + SESSION_DURATION });
+  
+  // Return an HTML page that auto-submits and redirects
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Auto-login</title>
+</head>
+<body>
+  <script>
+    // Set cookie and redirect
+    document.cookie = "session=${token}; Path=/; SameSite=Strict; Max-Age=${SESSION_DURATION / 1000}";
+    window.location.href = '/';
+  </script>
+</body>
+</html>`;
+  
+  return new Response(html, {
+    headers: { 
+      'Content-Type': 'text/html',
+      'Set-Cookie': `session=${token}; Path=/; HttpOnly; SameSite=Strict; Max-Age=${SESSION_DURATION / 1000}`
     }
   });
 }


### PR DESCRIPTION
- Create /auto-login route that automatically creates a session in dev mode
- Redirect browser to /auto-login on `bun run dev` for instant authentication
- Preserve logout functionality for testing auth flows
- Rename dev-with-tailwind.js to dev.js and add production guard
- Auto-login only activates in development, production auth unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
