### PR TITLE
Fix login failure on incorrect password

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -456,8 +456,11 @@ async function handleLogin(req: Request): Promise<Response> {
       },
     });
   } else {
-    // Show error
-    return htmlResponse(LoginPage({ error: "Invalid password" }) as string);
+    // Show error with 401 status
+    return new Response(LoginPage({ error: "Invalid password" }) as string, {
+      status: 401,
+      headers: { "Content-Type": "text/html" },
+    });
   }
 }
 


### PR DESCRIPTION
The login form was returning 200 OK status for failed login attempts,
causing the browser to reload the page instead of showing the error.
Changed to return 401 Unauthorized status for invalid passwords.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
