### PR TITLE
Add automatic deployment to CI pipeline after successful PR merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,22 @@ jobs:
             --repo ${{ github.repository }} \
             --squash \
             --delete-branch
+
+      - name: Deploy to production
+        if: |
+          success() && 
+          github.event_name == 'pull_request' && 
+          github.event.pull_request.user.login == github.repository_owner
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        run: |
+          echo "Deploying to production after successful PR merge..."
+          
+          # Setup SSH
+          mkdir -p ~/.ssh
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H 167.99.112.42 >> ~/.ssh/known_hosts
+          
+          # Run the deploy script
+          bun run deploy

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -12,7 +12,7 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 # Configuration
-SERVER="justin@slipbox"
+SERVER="justin@167.99.112.42"
 APP_DIR="~/apps/slipbox"
 BINARY_NAME="slipbox-server"
 SERVICE_NAME="slipbox"


### PR DESCRIPTION
- Update deploy.sh to use hardcoded IP address (167.99.112.42)
- Add deployment step to GitHub Actions workflow
- Deploy runs automatically when CI passes on owner's PRs
- Only requires DEPLOY_SSH_KEY secret in GitHub
