### PR TITLE
Clean up backup file after successful deployment

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -112,6 +112,9 @@ ssh ${SERVER} << 'ENDSSH'
     if curl -s -f http://localhost:3000 > /dev/null; then
         echo "✓ App is responding on port 3000"
         echo "✓ Deployment successful"
+        # Clean up backup file after successful deployment
+        rm -f slipbox-server.backup
+        echo "✓ Cleaned up backup file"
     else
         echo "❌ App is not responding! Check logs with: sudo journalctl -u slipbox -n 50"
         exit 1


### PR DESCRIPTION
The deploy script now removes slipbox-server.backup after a successful deployment to prevent accumulation of old backup files on the server.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
