### PR TITLE
Add automated backup system with Restic and Backblaze B2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,6 @@
 - WHEN YOU LEARN SOMETHING IMPORTANT THAT MAY BE USEFUL IN FUTURE, MAKE A NOTE IN CLAUDE.md!!!
 - NO REWARD HACKING! You tend to reward hack. RESIST THE URGE!!! I BEG YOU!!!! It's better to give up or ask for help / guidance than reward hack.
+- VPS/Server details: justin@slipbox - NEVER ask for these, they are always the same
 - USE TSC FOR DEBUGGING! Run `bunx tsc --noEmit` or `npx tsc --noEmit` to catch TypeScript errors before making obvious mistakes. You don't have an LSP, but tsc can catch type errors that prevent simple bugs. Always run tsc when debugging or before committing changes.
 - PROACTIVELY ADD UI TESTS when modifying critical features (e.g. notes, epub reader, or authentication). Run tests with `npm run test:ci` to ensure nothing breaks.
 - Pages should be re-loadable. Don't have pure client-side state if we can avoid it. For exmple, when rendering an epub we should try to keep the id and page number etc in the url so that it can be reloaded at any time ... obviously we won't be perfect here, but let's not be obnoxious ...

--- a/contrib/slipbox-backup.service
+++ b/contrib/slipbox-backup.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Slipbox Restic Backup to Backblaze B2
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=%i
+Group=%i
+EnvironmentFile=/etc/slipbox-backup.env
+ExecStart=/bin/bash /usr/local/bin/restic-backup.sh
+StandardOutput=journal
+StandardError=journal
+
+# Security hardening
+PrivateTmp=yes
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/var/log/slipbox-backup
+
+# Restart on failure with delay
+Restart=on-failure
+RestartSec=1h

--- a/contrib/slipbox-backup.timer
+++ b/contrib/slipbox-backup.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Run Slipbox backup every 6 hours
+Requires=slipbox-backup@.service
+
+[Timer]
+# Run every 6 hours
+OnCalendar=00,06,12,18:00:00
+# Run 10 minutes after boot if missed
+OnBootSec=10min
+# Persist last run time across reboots
+Persistent=true
+# Randomize start time by up to 30 minutes to avoid load spikes
+RandomizedDelaySec=30min
+
+[Install]
+WantedBy=timers.target

--- a/scripts/README-BACKUP.md
+++ b/scripts/README-BACKUP.md
@@ -1,0 +1,57 @@
+# Slipbox Backup System
+
+Automated backup system using Restic and Backblaze B2.
+
+## Quick Setup
+
+1. **Create Backblaze B2 account and bucket:**
+   - Sign up at [backblaze.com](https://www.backblaze.com/b2/sign-up.html)
+   - Create a private bucket (e.g., `slipbox-backup`)
+   - Create an App Key and save the credentials
+
+2. **Run on your server:**
+   ```bash
+   cd scripts/
+   sudo ./setup-backup.sh
+   ```
+
+3. **Enter your Backblaze credentials when prompted**
+
+## What It Does
+
+- Backs up `~/apps/slipbox` every 6 hours
+- Keeps 7 daily, 4 weekly, 12 monthly snapshots
+- Excludes: node_modules, .git, logs, tmp files
+- Runs integrity checks weekly
+
+## Commands
+
+```bash
+# Check backup status
+systemctl status slipbox-backup@username.timer
+
+# Run backup now
+systemctl start slipbox-backup@username.service
+
+# View logs
+journalctl -u slipbox-backup@username.service -f
+
+# List snapshots
+sudo -u username restic snapshots
+
+# Restore latest backup
+sudo -u username restic restore latest --target /path/to/restore
+```
+
+## Files
+
+- `/etc/slipbox-backup.env` - Credentials (mode 600)
+- `/usr/local/bin/restic-backup.sh` - Backup script
+- `/var/log/slipbox-backup/` - Log directory
+
+## Security
+
+- Credentials stored with restrictive permissions (600)
+- Systemd service runs as non-root user
+- Repository encrypted with generated password
+- **SAVE YOUR REPOSITORY PASSWORD!**

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -euo pipefail
+
+# Restic backup script for Slipbox data
+# This script backs up ~/apps/slipbox to Backblaze B2
+
+# Load environment variables
+if [ -f /etc/slipbox-backup.env ]; then
+    set -a
+    source /etc/slipbox-backup.env
+    set +a
+else
+    echo "Error: /etc/slipbox-backup.env not found"
+    echo "Please create it with your Backblaze credentials"
+    exit 1
+fi
+
+# Required environment variables check
+: "${B2_ACCOUNT_ID:?Need B2_ACCOUNT_ID}"
+: "${B2_ACCOUNT_KEY:?Need B2_ACCOUNT_KEY}"
+: "${RESTIC_REPOSITORY:?Need RESTIC_REPOSITORY}"
+: "${RESTIC_PASSWORD:?Need RESTIC_PASSWORD}"
+
+# Export for restic
+export B2_ACCOUNT_ID
+export B2_ACCOUNT_KEY
+export RESTIC_REPOSITORY
+export RESTIC_PASSWORD
+
+# Backup source
+BACKUP_SOURCE="$HOME/apps/slipbox"
+
+# Check if backup source exists
+if [ ! -d "$BACKUP_SOURCE" ]; then
+    echo "Error: Backup source $BACKUP_SOURCE does not exist"
+    exit 1
+fi
+
+echo "Starting backup at $(date)"
+
+# Initialize repository if it doesn't exist
+if ! restic cat config &>/dev/null; then
+    echo "Initializing restic repository..."
+    restic init
+else
+    echo "Repository already initialized"
+fi
+
+# Run backup
+echo "Backing up $BACKUP_SOURCE..."
+restic backup \
+    --verbose \
+    --tag "slipbox" \
+    --tag "auto" \
+    --exclude="node_modules" \
+    --exclude=".git" \
+    --exclude="*.log" \
+    --exclude="tmp/*" \
+    "$BACKUP_SOURCE"
+
+# Prune old snapshots (keep 7 daily, 4 weekly, 12 monthly)
+echo "Pruning old snapshots..."
+restic forget \
+    --keep-daily 7 \
+    --keep-weekly 4 \
+    --keep-monthly 12 \
+    --prune
+
+# Check repository integrity (run occasionally, not every backup)
+if [ "$(date +%u)" = "1" ]; then  # Only on Mondays
+    echo "Running repository check..."
+    restic check
+fi
+
+echo "Backup completed at $(date)"

--- a/scripts/restore-backup.sh
+++ b/scripts/restore-backup.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+# Restore script for Slipbox backups from Backblaze B2
+
+# Load environment variables
+if [ -f /etc/slipbox-backup.env ]; then
+    set -a
+    source /etc/slipbox-backup.env
+    set +a
+else
+    echo "Error: /etc/slipbox-backup.env not found"
+    exit 1
+fi
+
+# Export for restic
+export B2_ACCOUNT_ID
+export B2_ACCOUNT_KEY
+export RESTIC_REPOSITORY
+export RESTIC_PASSWORD
+
+echo "Slipbox Backup Restore Tool"
+echo "============================"
+echo ""
+
+# List available snapshots
+echo "Available snapshots:"
+restic snapshots
+
+echo ""
+echo "To restore a specific snapshot:"
+echo "  1. Note the snapshot ID from above"
+echo "  2. Run: restic restore <snapshot-id> --target /path/to/restore"
+echo ""
+echo "Example:"
+echo "  restic restore latest --target /tmp/restore-test"
+echo "  restic restore 3bf8a6c2 --target ~/apps/slipbox-restored"
+echo ""
+echo "To mount snapshots for browsing:"
+echo "  restic mount /mnt/restic"
+echo "  (then browse files and unmount when done)"

--- a/scripts/setup-backup.sh
+++ b/scripts/setup-backup.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+set -euo pipefail
+
+# Setup script for Slipbox Backblaze B2 backups with restic
+# Run this from your laptop - it will SSH to your server and set everything up
+
+echo "Slipbox Backup Setup"
+echo "===================="
+echo ""
+
+# VPS connection details
+VPS_HOST="slipbox"
+VPS_USER="justin"
+
+# Test SSH connection
+echo "Connecting to $VPS_USER@$VPS_HOST..."
+if ! ssh -o ConnectTimeout=5 "$VPS_USER@$VPS_HOST" "echo 'SSH connection successful'" 2>/dev/null; then
+    echo "Error: Cannot connect to $VPS_USER@$VPS_HOST"
+    echo "Please check your SSH config and try again"
+    exit 1
+fi
+
+# Get Backblaze credentials
+echo ""
+echo "Please enter your Backblaze B2 credentials:"
+echo "(Get these from Backblaze B2 > App Keys)"
+read -p "B2 Account ID (keyID): " B2_ACCOUNT_ID
+read -s -p "B2 Application Key: " B2_ACCOUNT_KEY
+echo ""
+read -p "B2 Bucket Name: " B2_BUCKET
+
+# Generate a secure password for restic repository
+echo ""
+echo "Generating secure repository password..."
+RESTIC_PASSWORD=$(openssl rand -base64 32)
+echo ""
+echo "================================================"
+echo "IMPORTANT: SAVE THIS PASSWORD!"
+echo "Repository password: $RESTIC_PASSWORD"
+echo "================================================"
+echo ""
+read -p "Press enter after you've saved the password..."
+
+# Create the environment file content
+ENV_FILE_CONTENT=$(cat << EOF
+# Backblaze B2 credentials
+B2_ACCOUNT_ID="$B2_ACCOUNT_ID"
+B2_ACCOUNT_KEY="$B2_ACCOUNT_KEY"
+
+# Restic repository configuration
+RESTIC_REPOSITORY="b2:$B2_BUCKET:/slipbox-backup"
+RESTIC_PASSWORD="$RESTIC_PASSWORD"
+
+# Backup configuration
+BACKUP_USER="$VPS_USER"
+EOF
+)
+
+echo ""
+echo "Setting up backup system on server..."
+
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Copy necessary files to server
+echo "Copying files to server..."
+scp -q "$SCRIPT_DIR/backup.sh" "$SCRIPT_DIR/restore-backup.sh" "$VPS_USER@$VPS_HOST:/tmp/"
+scp -q "$SCRIPT_DIR/../contrib/slipbox-backup.service" "$SCRIPT_DIR/../contrib/slipbox-backup.timer" "$VPS_USER@$VPS_HOST:/tmp/"
+
+# Run setup commands on server
+ssh "$VPS_USER@$VPS_HOST" bash << 'REMOTE_SCRIPT'
+set -euo pipefail
+
+echo "Installing restic..."
+if ! command -v restic &> /dev/null; then
+    sudo apt-get update -qq
+    sudo apt-get install -y -qq restic
+else
+    echo "Restic already installed"
+fi
+
+echo "Setting up backup configuration..."
+
+# Create environment file
+sudo tee /etc/slipbox-backup.env > /dev/null << 'ENV_EOF'
+PLACEHOLDER_ENV_CONTENT
+ENV_EOF
+
+# Secure the environment file
+sudo chmod 600 /etc/slipbox-backup.env
+sudo chown root:root /etc/slipbox-backup.env
+
+# Install backup scripts
+echo "Installing backup scripts..."
+sudo cp /tmp/backup.sh /usr/local/bin/restic-backup.sh
+sudo cp /tmp/restore-backup.sh /usr/local/bin/restic-restore.sh
+sudo chmod 755 /usr/local/bin/restic-backup.sh
+sudo chmod 755 /usr/local/bin/restic-restore.sh
+
+# Create log directory
+sudo mkdir -p /var/log/slipbox-backup
+sudo chown "$USER:$USER" /var/log/slipbox-backup
+
+# Install systemd services
+echo "Installing systemd services..."
+sudo cp /tmp/slipbox-backup.service /etc/systemd/system/slipbox-backup@.service
+sudo cp /tmp/slipbox-backup.timer "/etc/systemd/system/slipbox-backup@$USER.timer"
+
+# Clean up temp files
+rm -f /tmp/backup.sh /tmp/restore-backup.sh /tmp/slipbox-backup.service /tmp/slipbox-backup.timer
+
+# Reload systemd
+sudo systemctl daemon-reload
+
+# Enable and start the timer
+echo "Enabling backup timer..."
+sudo systemctl enable "slipbox-backup@$USER.timer"
+sudo systemctl start "slipbox-backup@$USER.timer"
+
+echo "Server setup complete!"
+REMOTE_SCRIPT
+
+# Replace placeholder with actual environment content using a more robust method
+ssh "$VPS_USER@$VPS_HOST" "sudo bash -c 'cat > /etc/slipbox-backup.env << EOF
+$ENV_FILE_CONTENT
+EOF
+chmod 640 /etc/slipbox-backup.env
+chown root:$VPS_USER /etc/slipbox-backup.env'"
+
+# Initialize repository
+echo ""
+echo "Initializing backup repository..."
+ssh "$VPS_USER@$VPS_HOST" "sudo -E bash -c 'source /etc/slipbox-backup.env && export B2_ACCOUNT_ID B2_ACCOUNT_KEY RESTIC_REPOSITORY RESTIC_PASSWORD && restic init 2>/dev/null || echo Repository already initialized'"
+
+# Run a test backup
+echo ""
+echo "Running initial backup test..."
+ssh "$VPS_USER@$VPS_HOST" "sudo systemctl start slipbox-backup@$VPS_USER.service"
+
+echo ""
+echo "================================================"
+echo "Setup complete!"
+echo "================================================"
+echo ""
+echo "Backup schedule: Every 6 hours"
+echo ""
+echo "Useful commands (run on server):"
+echo "  - Check status: systemctl status slipbox-backup@$VPS_USER.timer"
+echo "  - View logs: journalctl -u slipbox-backup@$VPS_USER.service -f"
+echo "  - Run backup now: sudo systemctl start slipbox-backup@$VPS_USER.service"
+echo "  - List snapshots: sudo -u $VPS_USER restic-restore.sh"
+echo ""
+echo "IMPORTANT: Repository password saved above!"
+echo "Password: $RESTIC_PASSWORD"


### PR DESCRIPTION
- Automated backups every 6 hours via systemd timer
- Uses Restic for efficient incremental backups to Backblaze B2
- Smart retention: 7 daily, 4 weekly, 12 monthly snapshots
- One-command setup script that runs from laptop and configures VPS
- Includes restore helper script for easy recovery

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
