### PR TITLE
Convert backup service from templated to non-templated

### DIFF
--- a/contrib/slipbox-backup.service
+++ b/contrib/slipbox-backup.service
@@ -5,8 +5,8 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-User=%i
-Group=%i
+User=justin
+Group=justin
 EnvironmentFile=/etc/slipbox-backup.env
 ExecStart=/bin/bash /usr/local/bin/restic-backup.sh
 StandardOutput=journal

--- a/contrib/slipbox-backup.timer
+++ b/contrib/slipbox-backup.timer
@@ -1,6 +1,6 @@
 [Unit]
 Description=Run Slipbox backup every 6 hours
-Requires=slipbox-backup@.service
+Requires=slipbox-backup.service
 
 [Timer]
 # Run every 6 hours

--- a/scripts/README-BACKUP.md
+++ b/scripts/README-BACKUP.md
@@ -28,13 +28,13 @@ Automated backup system using Restic and Backblaze B2.
 
 ```bash
 # Check backup status
-systemctl status slipbox-backup@username.timer
+systemctl status slipbox-backup.timer
 
 # Run backup now
-systemctl start slipbox-backup@username.service
+systemctl start slipbox-backup.service
 
 # View logs
-journalctl -u slipbox-backup@username.service -f
+journalctl -u slipbox-backup -f
 
 # List snapshots
 sudo -u username restic snapshots

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -71,7 +71,7 @@ else
 fi
 
 # Step 6: Deploy on server
-echo -e "\n${YELLOW}🔧 Syncing systemd service file...${NC}"
+echo -e "\n${YELLOW}🔧 Syncing systemd service files...${NC}"
 # Compare and sync systemd service file if different
 TEMP_SERVICE_FILE=$(mktemp)
 ssh ${SERVER} "cat /etc/systemd/system/slipbox.service" > ${TEMP_SERVICE_FILE} 2>/dev/null || true
@@ -89,6 +89,92 @@ else
     echo -e "${RED}   ⚠ contrib/slipbox.service not found in repo${NC}"
 fi
 rm -f ${TEMP_SERVICE_FILE}
+
+# Update backup service files if they exist on the server
+echo -e "\n${YELLOW}🔧 Checking for backup service files...${NC}"
+BACKUP_EXISTS=$(ssh ${SERVER} "ls /etc/systemd/system/slipbox-backup*.service 2>/dev/null | head -1" || echo "")
+
+if [ -n "${BACKUP_EXISTS}" ]; then
+    echo -e "${YELLOW}   Backup service detected, checking for updates...${NC}"
+    
+    # Determine if it's the old templated (@justin) or new non-templated version
+    if ssh ${SERVER} "test -f /etc/systemd/system/slipbox-backup@.service"; then
+        # Old templated version exists, need to migrate
+        echo -e "${YELLOW}   Migrating from templated to non-templated backup service...${NC}"
+        
+        # Upload new service files
+        scp contrib/slipbox-backup.service ${SERVER}:/tmp/
+        scp contrib/slipbox-backup.timer ${SERVER}:/tmp/
+        
+        # Migrate on server
+        ssh ${SERVER} << 'MIGRATE_BACKUP'
+            set -e
+            # Stop old timer
+            sudo systemctl stop slipbox-backup@justin.timer 2>/dev/null || true
+            sudo systemctl disable slipbox-backup@justin.timer 2>/dev/null || true
+            
+            # Install new service files
+            sudo mv /tmp/slipbox-backup.service /etc/systemd/system/
+            sudo mv /tmp/slipbox-backup.timer /etc/systemd/system/
+            
+            # Remove old templated files
+            sudo rm -f /etc/systemd/system/slipbox-backup@.service
+            sudo rm -f /etc/systemd/system/slipbox-backup@*.timer
+            
+            # Reload and start new timer
+            sudo systemctl daemon-reload
+            sudo systemctl enable slipbox-backup.timer
+            sudo systemctl start slipbox-backup.timer
+            
+            echo "   ✓ Migrated to non-templated backup service"
+MIGRATE_BACKUP
+        echo -e "${GREEN}   ✓ Backup service migrated successfully${NC}"
+        
+    elif ssh ${SERVER} "test -f /etc/systemd/system/slipbox-backup.service"; then
+        # Already using non-templated version, just update if needed
+        TEMP_BACKUP_SERVICE=$(mktemp)
+        TEMP_BACKUP_TIMER=$(mktemp)
+        
+        ssh ${SERVER} "cat /etc/systemd/system/slipbox-backup.service" > ${TEMP_BACKUP_SERVICE} 2>/dev/null || true
+        ssh ${SERVER} "cat /etc/systemd/system/slipbox-backup.timer" > ${TEMP_BACKUP_TIMER} 2>/dev/null || true
+        
+        NEEDS_UPDATE=false
+        
+        if [ -f "contrib/slipbox-backup.service" ] && ! cmp -s "contrib/slipbox-backup.service" ${TEMP_BACKUP_SERVICE}; then
+            echo -e "${YELLOW}   Backup service file differs, updating...${NC}"
+            scp contrib/slipbox-backup.service ${SERVER}:/tmp/
+            NEEDS_UPDATE=true
+        fi
+        
+        if [ -f "contrib/slipbox-backup.timer" ] && ! cmp -s "contrib/slipbox-backup.timer" ${TEMP_BACKUP_TIMER}; then
+            echo -e "${YELLOW}   Backup timer file differs, updating...${NC}"
+            scp contrib/slipbox-backup.timer ${SERVER}:/tmp/
+            NEEDS_UPDATE=true
+        fi
+        
+        if [ "${NEEDS_UPDATE}" = true ]; then
+            ssh ${SERVER} << 'UPDATE_BACKUP'
+                set -e
+                if [ -f /tmp/slipbox-backup.service ]; then
+                    sudo mv /tmp/slipbox-backup.service /etc/systemd/system/
+                fi
+                if [ -f /tmp/slipbox-backup.timer ]; then
+                    sudo mv /tmp/slipbox-backup.timer /etc/systemd/system/
+                fi
+                sudo systemctl daemon-reload
+                sudo systemctl restart slipbox-backup.timer
+                echo "   ✓ Backup service files updated"
+UPDATE_BACKUP
+            echo -e "${GREEN}   ✓ Backup service updated successfully${NC}"
+        else
+            echo -e "${GREEN}   ✓ Backup service files are up to date${NC}"
+        fi
+        
+        rm -f ${TEMP_BACKUP_SERVICE} ${TEMP_BACKUP_TIMER}
+    fi
+else
+    echo -e "${YELLOW}   No backup service found on server (run setup-backup.sh to install)${NC}"
+fi
 
 echo -e "\n${YELLOW}🔄 Deploying on server...${NC}"
 ssh ${SERVER} << 'ENDSSH'

--- a/scripts/setup-backup.sh
+++ b/scripts/setup-backup.sh
@@ -103,8 +103,8 @@ sudo chown "$USER:$USER" /var/log/slipbox-backup
 
 # Install systemd services
 echo "Installing systemd services..."
-sudo cp /tmp/slipbox-backup.service /etc/systemd/system/slipbox-backup@.service
-sudo cp /tmp/slipbox-backup.timer "/etc/systemd/system/slipbox-backup@$USER.timer"
+sudo cp /tmp/slipbox-backup.service /etc/systemd/system/slipbox-backup.service
+sudo cp /tmp/slipbox-backup.timer /etc/systemd/system/slipbox-backup.timer
 
 # Clean up temp files
 rm -f /tmp/backup.sh /tmp/restore-backup.sh /tmp/slipbox-backup.service /tmp/slipbox-backup.timer
@@ -114,8 +114,8 @@ sudo systemctl daemon-reload
 
 # Enable and start the timer
 echo "Enabling backup timer..."
-sudo systemctl enable "slipbox-backup@$USER.timer"
-sudo systemctl start "slipbox-backup@$USER.timer"
+sudo systemctl enable slipbox-backup.timer
+sudo systemctl start slipbox-backup.timer
 
 echo "Server setup complete!"
 REMOTE_SCRIPT
@@ -135,7 +135,7 @@ ssh "$VPS_USER@$VPS_HOST" "sudo -E bash -c 'source /etc/slipbox-backup.env && ex
 # Run a test backup
 echo ""
 echo "Running initial backup test..."
-ssh "$VPS_USER@$VPS_HOST" "sudo systemctl start slipbox-backup@$VPS_USER.service"
+ssh "$VPS_USER@$VPS_HOST" "sudo systemctl start slipbox-backup.service"
 
 echo ""
 echo "================================================"
@@ -145,9 +145,9 @@ echo ""
 echo "Backup schedule: Every 6 hours"
 echo ""
 echo "Useful commands (run on server):"
-echo "  - Check status: systemctl status slipbox-backup@$VPS_USER.timer"
-echo "  - View logs: journalctl -u slipbox-backup@$VPS_USER.service -f"
-echo "  - Run backup now: sudo systemctl start slipbox-backup@$VPS_USER.service"
+echo "  - Check status: systemctl status slipbox-backup.timer"
+echo "  - View logs: journalctl -u slipbox-backup -f"
+echo "  - Run backup now: sudo systemctl start slipbox-backup.service"
 echo "  - List snapshots: sudo -u $VPS_USER restic-restore.sh"
 echo ""
 echo "IMPORTANT: Repository password saved above!"


### PR DESCRIPTION
- Remove template parameter (%i) from slipbox-backup.service
- Update setup-backup.sh to use non-templated service files
- Update deploy.sh to auto-migrate existing templated services
- Simplify journalctl commands (now just 'journalctl -u slipbox-backup')
- Update documentation to reflect simplified service names

This change makes the backup service easier to manage since we only
run one instance per server.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
