### PR TITLE
Simplify CI deployment with server-side tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,49 +34,48 @@ jobs:
         if: success()
         run: |
           set -euo pipefail
-          echo "Building production binary with script..."
+          echo "=== Deployment v2: CI User Profile ==="
+          echo "Building production binary..."
           bash scripts/build-binary.sh
           
           echo "Adding binary to Nix store..."
-          # Add the binary directly to the store
-          STORE_PATH=$(nix store add-file dist/slipbox-linux --name slipbox)
+          STORE_PATH=$(nix store add-file dist/slipbox-linux --name slipbox-server)
           echo "Binary added to store: $STORE_PATH"
           
-          # Create a simple derivation that references the binary
-          cat > default.nix <<'NIXEOF'
+          # Create wrapper package
+          cat > slipbox-wrapper.nix <<'NIXEOF'
           { pkgs ? import <nixpkgs> {} }:
-          pkgs.runCommand "slipbox-binary" {} ''
+          pkgs.runCommand "slipbox-server" {} ''
             mkdir -p $out/bin
-            ln -s STORE_PATH_PLACEHOLDER $out/bin/slipbox
+            ln -s STORE_PATH_PLACEHOLDER $out/bin/slipbox-server
           ''
           NIXEOF
           
-          # Replace placeholder with actual store path
-          sed -i "s|STORE_PATH_PLACEHOLDER|$STORE_PATH|" default.nix
+          sed -i "s|STORE_PATH_PLACEHOLDER|$STORE_PATH|" slipbox-wrapper.nix
           
           echo "Building wrapper package..."
-          out=$(nix-build default.nix --no-out-link)
-          echo "Built package: $out"
+          WRAPPER_PATH=$(nix-build slipbox-wrapper.nix --no-out-link)
+          echo "Built package: $WRAPPER_PATH"
           
-          echo "Installing to user profile..."
-          # Use a user-owned profile that doesn't require sudo
-          mkdir -p ~/.nix-profiles
-          nix profile install --profile ~/.nix-profiles/slipbox "$out"
+          echo "Installing to CI user's profile..."
+          # Install to CI user's profile (justin has sudo rights to do this)
+          sudo -u ci nix profile upgrade --profile /nix/var/nix/profiles/per-user/ci/slipbox "$WRAPPER_PATH" 2>/dev/null || \
+          sudo -u ci nix profile install --profile /nix/var/nix/profiles/per-user/ci/slipbox "$WRAPPER_PATH"
           
-          echo "Creating symlink for service..."
-          # Create a symlink that the service can use (in justin's home)
-          rm -f /home/justin/slipbox-binary
-          ln -s ~/.nix-profiles/slipbox/bin/slipbox /home/justin/slipbox-binary
+          echo "Restarting service (CI user has polkit permissions)..."
+          sudo -u ci systemctl restart slipbox
           
-          echo "Triggering service restart via touch file..."
-          # Touch a file that a watcher can detect to restart the service
-          touch /home/justin/slipbox-deploy-trigger
-          
-          echo "Waiting for service restart..."
+          echo "Waiting for service to start..."
           sleep 5
           
           echo "Verifying service health..."
-          curl -fsS http://localhost:3000/ >/dev/null && echo "Service is healthy!" || echo "Warning: Service health check failed"
+          if systemctl is-active slipbox && curl -fsS http://localhost:3000/ >/dev/null; then
+            echo "✅ Deployment successful! Service is healthy"
+          else
+            echo "❌ Service health check failed"
+            systemctl status slipbox --no-pager | head -20
+            exit 1
+          fi
 
       - name: Auto-merge PR
         if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Deploy to production
         if: success()
-        run: ci-deploy slipbox dist/slipbox-linux
+        run: ci-deploy slipbox dist/slipbox
 
       - name: Auto-merge PR
         if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,50 +32,7 @@ jobs:
 
       - name: Deploy to production
         if: success()
-        run: |
-          set -euo pipefail
-          echo "=== Deployment v2: CI User Profile ==="
-          echo "Building production binary..."
-          bash scripts/build-binary.sh
-          
-          echo "Adding binary to Nix store..."
-          STORE_PATH=$(nix store add-file dist/slipbox-linux --name slipbox-server)
-          echo "Binary added to store: $STORE_PATH"
-          
-          # Create wrapper package
-          cat > slipbox-wrapper.nix <<'NIXEOF'
-          { pkgs ? import <nixpkgs> {} }:
-          pkgs.runCommand "slipbox-server" {} ''
-            mkdir -p $out/bin
-            ln -s STORE_PATH_PLACEHOLDER $out/bin/slipbox-server
-          ''
-          NIXEOF
-          
-          sed -i "s|STORE_PATH_PLACEHOLDER|$STORE_PATH|" slipbox-wrapper.nix
-          
-          echo "Building wrapper package..."
-          WRAPPER_PATH=$(nix-build slipbox-wrapper.nix --no-out-link)
-          echo "Built package: $WRAPPER_PATH"
-          
-          echo "Installing to CI user's profile..."
-          # Install to CI user's profile (justin has sudo rights to do this)
-          sudo -u ci nix profile upgrade --profile /nix/var/nix/profiles/per-user/ci/slipbox "$WRAPPER_PATH" 2>/dev/null || \
-          sudo -u ci nix profile install --profile /nix/var/nix/profiles/per-user/ci/slipbox "$WRAPPER_PATH"
-          
-          echo "Restarting service (CI user has polkit permissions)..."
-          sudo -u ci systemctl restart slipbox
-          
-          echo "Waiting for service to start..."
-          sleep 5
-          
-          echo "Verifying service health..."
-          if systemctl is-active slipbox && curl -fsS http://localhost:3000/ >/dev/null; then
-            echo "✅ Deployment successful! Service is healthy"
-          else
-            echo "❌ Service health check failed"
-            systemctl status slipbox --no-pager | head -20
-            exit 1
-          fi
+        run: ci-deploy slipbox dist/slipbox-linux
 
       - name: Auto-merge PR
         if: |

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -10,7 +10,7 @@ NC='\033[0m' # No Color
 echo -e "${YELLOW}Building production binary...${NC}"
 
 # Clean up any previous build artifacts
-rm -f dist/slipbox-linux dist/slipbox-darwin
+rm -f dist/slipbox dist/slipbox-linux dist/slipbox-darwin
 
 # Build client assets first
 echo -e "${YELLOW}Building client assets...${NC}"
@@ -19,15 +19,14 @@ bun run build:client
 # Build the binary for current platform
 echo -e "${YELLOW}Building binary with embedded assets...${NC}"
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    NODE_ENV=production EMBED_ASSETS=true bun build src/index.ts --compile --outfile dist/slipbox-darwin
-    BINARY_FILE="dist/slipbox-darwin"
+    NODE_ENV=production EMBED_ASSETS=true bun build src/index.ts --compile --outfile dist/slipbox
 elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    NODE_ENV=production EMBED_ASSETS=true bun build src/index.ts --compile --target=bun-linux-x64 --outfile dist/slipbox-linux
-    BINARY_FILE="dist/slipbox-linux"
+    NODE_ENV=production EMBED_ASSETS=true bun build src/index.ts --compile --target=bun-linux-x64 --outfile dist/slipbox
 else
     echo -e "${RED}Unsupported platform: $OSTYPE${NC}"
     exit 1
 fi
+BINARY_FILE="dist/slipbox"
 
 # Check binary was created
 if [ ! -f "$BINARY_FILE" ]; then

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -16,17 +16,29 @@ rm -f dist/slipbox dist/slipbox-linux dist/slipbox-darwin
 echo -e "${YELLOW}Building client assets...${NC}"
 bun run build:client
 
-# Build the binary for current platform
+# Build binaries
 echo -e "${YELLOW}Building binary with embedded assets...${NC}"
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    NODE_ENV=production EMBED_ASSETS=true bun build src/index.ts --compile --outfile dist/slipbox
+    # On Mac, build both Darwin and Linux versions
+    echo "Building Darwin binary..."
+    NODE_ENV=production EMBED_ASSETS=true bun build src/index.ts --compile --outfile dist/slipbox-darwin
+    echo "Building Linux binary..."
+    NODE_ENV=production EMBED_ASSETS=true bun build src/index.ts --compile --target=bun-linux-x64 --outfile dist/slipbox-linux
+    BINARY_FILE="dist/slipbox-darwin"
 elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    NODE_ENV=production EMBED_ASSETS=true bun build src/index.ts --compile --target=bun-linux-x64 --outfile dist/slipbox
+    # On Linux, build Linux version (can't cross-compile to Darwin with bun)
+    NODE_ENV=production EMBED_ASSETS=true bun build src/index.ts --compile --target=bun-linux-x64 --outfile dist/slipbox-linux
+    BINARY_FILE="dist/slipbox-linux"
 else
     echo -e "${RED}Unsupported platform: $OSTYPE${NC}"
     exit 1
 fi
-BINARY_FILE="dist/slipbox"
+
+# For deployment, copy the Linux binary to the standard name
+if [ -f "dist/slipbox-linux" ]; then
+    cp dist/slipbox-linux dist/slipbox
+    echo -e "${GREEN}✓ Copied Linux binary to dist/slipbox for deployment${NC}"
+fi
 
 # Check binary was created
 if [ ! -f "$BINARY_FILE" ]; then

--- a/scripts/manual-deploy.sh
+++ b/scripts/manual-deploy.sh
@@ -5,4 +5,4 @@ DIR=$(ssh justin@135.181.179.143 "mktemp -d /tmp/slipbox-XXXXXX")
 echo "🚀 Deploying to $DIR"
 
 hsync . "justin@135.181.179.143:$DIR"
-ssh justin@135.181.179.143 "cd $DIR && nix run .#ci && ci-deploy slipbox dist/slipbox-linux"
+ssh justin@135.181.179.143 "cd $DIR && nix run .#ci && ci-deploy slipbox dist/slipbox"

--- a/scripts/manual-deploy.sh
+++ b/scripts/manual-deploy.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR=$(ssh justin@135.181.179.143 "mktemp -d /tmp/slipbox-XXXXXX")
+echo "🚀 Deploying to $DIR"
+
+hsync . "justin@135.181.179.143:$DIR"
+ssh justin@135.181.179.143 "cd $DIR && nix run .#ci && ci-deploy slipbox dist/slipbox-linux"


### PR DESCRIPTION
## Summary
- CI deployment reduced to one line: `ci-deploy slipbox dist/slipbox`
- All deployment logic moved to server-side `ci-deploy` tool
- Binary renamed to just `slipbox` for consistency

## Changes
1. **CI workflow** - Now just calls `ci-deploy slipbox dist/slipbox`
2. **build-binary.sh** - Outputs `dist/slipbox` instead of `dist/slipbox-linux`
3. **manual-deploy.sh** - Added for easy testing of deployments

## Server-side changes (already deployed)
- Created `ci-deploy` tool in `/Users/justin/configs/hetzner/ci-deploy.nix`
- Simplified `hsync` to 5 lines
- Tool handles: Nix store, wrapper packages, CI profile installation, service restart

## Testing
Manually tested on server:
```bash
$ ./scripts/manual-deploy.sh
🚀 Deploying to /tmp/slipbox-tLG5eM
[builds and tests pass]
✅ slipbox deployed successfully!
```

The binary gets installed to `/nix/var/nix/profiles/per-user/ci/slipbox/bin/slipbox`

## Next steps
- Update slipbox.service to use CI profile path instead of `/home/justin/slipbox-binary`

🤖 Generated with [Claude Code](https://claude.ai/code)