### PR TITLE
Fix deployment pipeline with consistent build directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,7 @@ jobs:
 
       - name: Run CI
         run: |
-          # TODO: Re-enable tests once deployment is fixed
-          # nix run .#ci
-          echo "Skipping tests temporarily for faster iteration"
+          nix run .#ci
 
       - name: Build production package
         if: success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
 
       - name: Run CI
         run: |
-          nix run .#ci
+          # TODO: Re-enable after deployment is fixed
+          # nix run .#ci
+          echo "Skipping tests for deployment debugging"
 
       - name: Build production package
         if: success()
@@ -39,10 +41,12 @@ jobs:
       - name: Deploy to production
         if: success()
         run: |
-          # Clean and sync to consistent build directory for nix profile tracking
-          rm -rf /build/slipbox
-          mkdir -p /build/slipbox
-          cp -r . /build/slipbox/
+          # Clean and sync to consistent build directory
+          # Only clean contents, not the directory itself (justin doesn't own /build)
+          rm -rf /build/slipbox/*
+          rm -rf /build/slipbox/.??* 2>/dev/null || true
+          # Copy all files and folders, excluding .git to save space
+          rsync -av --exclude='.git' --exclude='node_modules' --exclude='result' . /build/slipbox/
           cd /build/slipbox
           ci-deploy slipbox .#slipbox
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,17 +17,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          path: /build/slipbox
 
       - name: Run CI
-        working-directory: /build/slipbox
         run: |
           nix run .#ci
 
       - name: Build production package
         if: success()
-        working-directory: /build/slipbox
         run: |
           nix build .#slipbox
           echo "Store path: $(readlink result)"
@@ -37,13 +33,18 @@ jobs:
         if: always()
         with:
           name: playwright-report
-          path: /build/slipbox/playwright-report/
+          path: playwright-report/
           retention-days: 30
 
       - name: Deploy to production
         if: success()
-        working-directory: /build/slipbox
-        run: ci-deploy slipbox .#slipbox
+        run: |
+          # Clean and sync to consistent build directory for nix profile tracking
+          rm -rf /build/slipbox
+          mkdir -p /build/slipbox
+          cp -r . /build/slipbox/
+          cd /build/slipbox
+          ci-deploy slipbox .#slipbox
 
       - name: Auto-merge PR
         if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          path: /build/slipbox
 
       - name: Run CI
+        working-directory: /build/slipbox
         run: |
           nix run .#ci
 
       - name: Build production package
         if: success()
+        working-directory: /build/slipbox
         run: |
           nix build .#slipbox
           echo "Store path: $(readlink result)"
@@ -33,11 +37,12 @@ jobs:
         if: always()
         with:
           name: playwright-report
-          path: playwright-report/
+          path: /build/slipbox/playwright-report/
           retention-days: 30
 
       - name: Deploy to production
         if: success()
+        working-directory: /build/slipbox
         run: ci-deploy slipbox .#slipbox
 
       - name: Auto-merge PR

--- a/scripts/manual-deploy.sh
+++ b/scripts/manual-deploy.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DIR=$(ssh justin@135.181.179.143 "mktemp -d /tmp/slipbox-XXXXXX")
-echo "🚀 Deploying to $DIR"
+# Use a consistent directory for deployments so nix profile upgrade works
+DEPLOY_DIR="/build/slipbox"
+echo "🚀 Deploying to $DEPLOY_DIR"
 
-hsync . "justin@135.181.179.143:$DIR"
-ssh justin@135.181.179.143 "cd $DIR && nix build .#slipbox && ci-deploy slipbox .#slipbox"
+# Sync code to build directory
+hsync . "justin@135.181.179.143:$DEPLOY_DIR"
+
+# Build and deploy
+ssh justin@135.181.179.143 "cd $DEPLOY_DIR && nix build .#slipbox && ci-deploy slipbox .#slipbox"

--- a/src/templates/LoginPage.tsx
+++ b/src/templates/LoginPage.tsx
@@ -8,7 +8,7 @@ export function LoginPage(props?: { error?: string }) {
       <div class="min-h-screen flex items-center justify-center">
         <div class="w-full max-w-md p-8">
           <div class="bg-off-white border-2 border-dark p-8 shadow-[5px_5px_0px_0px_#111]">
-            <h1 class="text-3xl font-bold mb-8 text-center">🌟 Slipbox</h1>
+            <h1 class="text-3xl font-bold mb-8 text-center">🚀 Slipbox</h1>
 
             {error && (
               <div class="bg-red-100 border-2 border-red-400 text-red-700 px-4 py-3 mb-6">

--- a/src/templates/LoginPage.tsx
+++ b/src/templates/LoginPage.tsx
@@ -8,7 +8,7 @@ export function LoginPage(props?: { error?: string }) {
       <div class="min-h-screen flex items-center justify-center">
         <div class="w-full max-w-md p-8">
           <div class="bg-off-white border-2 border-dark p-8 shadow-[5px_5px_0px_0px_#111]">
-            <h1 class="text-3xl font-bold mb-8 text-center">🚀 Slipbox</h1>
+            <h1 class="text-3xl font-bold mb-8 text-center">📚 Slipbox</h1>
 
             {error && (
               <div class="bg-red-100 border-2 border-red-400 text-red-700 px-4 py-3 mb-6">

--- a/src/templates/LoginPage.tsx
+++ b/src/templates/LoginPage.tsx
@@ -8,7 +8,7 @@ export function LoginPage(props?: { error?: string }) {
       <div class="min-h-screen flex items-center justify-center">
         <div class="w-full max-w-md p-8">
           <div class="bg-off-white border-2 border-dark p-8 shadow-[5px_5px_0px_0px_#111]">
-            <h1 class="text-3xl font-bold mb-8 text-center">✨ Slipbox</h1>
+            <h1 class="text-3xl font-bold mb-8 text-center">🌟 Slipbox</h1>
 
             {error && (
               <div class="bg-red-100 border-2 border-red-400 text-red-700 px-4 py-3 mb-6">


### PR DESCRIPTION
## Summary
- Use /build/slipbox as consistent directory for all deployments so nix profile upgrade works
- Fix ci-deploy to remove and reinstall packages (upgrade fails when flake paths change)
- Re-enable tests in CI now that deployment is fixed
- Test with rocket emoji 🚀

## Changes
1. Updated manual-deploy.sh to use /build/slipbox instead of temp directories
2. Fixed ci-deploy.nix to remove existing installation before reinstalling
3. Re-enabled tests in CI workflow
4. Disabled PrivateTmp and added /tmp to ReadWritePaths for slipbox service (Bun needs temp access)

## Test Results
✅ Manual deployment from /build/slipbox - successful
✅ Upgrade deployment (remove + reinstall) - successful
🔄 GitHub Actions CI deployment - testing now

This PR fixes the deployment issues we've been having where deployments weren't actually updating the running service.