### PR TITLE
CI: Skip redundant CI tests on push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           nix build .#server --impure --option sandbox false
 
       - name: Run CI tests with Nix
+        if: github.event_name == 'pull_request'
         run: |
           nix run .#ci --impure --option sandbox false
 


### PR DESCRIPTION
One-line change to skip running `nix run .#ci` on pushes to master since these tests already ran in the PR before merging.

This avoids redundant test runs while still building and smoke-testing on master pushes.